### PR TITLE
Fix issue 10: Headers are not sent for prepared responses

### DIFF
--- a/src/main/java/de/hanbei/httpserver/MockHttpHandler.java
+++ b/src/main/java/de/hanbei/httpserver/MockHttpHandler.java
@@ -102,7 +102,6 @@ class MockHttpHandler implements HttpHandler {
     private void sendHeaders(HttpExchange httpExchange, Response response) throws IOException {
         int length = response.getContent().getLength();
         int statusCode = response.getStatus().getStatusCode();
-        httpExchange.sendResponseHeaders(statusCode, max(0, length));
 
         Headers responseHeaders = httpExchange.getResponseHeaders();
         Header headers = response.getHeader();
@@ -111,11 +110,18 @@ class MockHttpHandler implements HttpHandler {
                 responseHeaders.add(headerField, value.toString());
             }
         }
-        responseHeaders.add(Header.Fields.CONTENT_ENCODING, response.getContent().getEncoding());
-        responseHeaders.add(Header.Fields.CONTENT_LANGUAGE, response.getContent().getLanguage());
-        responseHeaders.add(Header.Fields.CONTENT_MD5, response.getContent().getMd5());
-        responseHeaders.add(Header.Fields.CONTENT_TYPE, response.getContent().getMimetype());
-        responseHeaders.add(Header.Fields.CONTENT_RANGE, response.getContent().getRange());
+        addHeaderIfSet(responseHeaders, Header.Fields.CONTENT_ENCODING, response.getContent().getEncoding());
+        addHeaderIfSet(responseHeaders, Header.Fields.CONTENT_LANGUAGE, response.getContent().getLanguage());
+        addHeaderIfSet(responseHeaders, Header.Fields.CONTENT_MD5, response.getContent().getMd5());
+        addHeaderIfSet(responseHeaders, Header.Fields.CONTENT_TYPE, response.getContent().getComposedContentType());
+        addHeaderIfSet(responseHeaders, Header.Fields.CONTENT_RANGE, response.getContent().getRange());
+        httpExchange.sendResponseHeaders(statusCode, max(0, length));
+    }
+
+    private void addHeaderIfSet(Headers responseHeaders, String name, String value) {
+        if(value != null) {
+            responseHeaders.add(name, value);
+        }
     }
 
     private Response getResponse(URI requestUri1, Method method) {

--- a/src/main/java/de/hanbei/httpserver/common/Content.java
+++ b/src/main/java/de/hanbei/httpserver/common/Content.java
@@ -42,6 +42,17 @@ public class Content {
     private String range;
     private boolean string;
 
+    public String getComposedContentType() {
+        if ( mimetype != null ) {
+            if ( charset == null ) {
+                return mimetype;
+            } else {
+                return mimetype + "; charset=" + charset;
+            }
+        }
+        return null;
+    }
+
     public String getMimetype() {
         return mimetype;
     }

--- a/src/main/java/de/hanbei/httpserver/response/ResponseBuilder.java
+++ b/src/main/java/de/hanbei/httpserver/response/ResponseBuilder.java
@@ -198,7 +198,6 @@ public class ResponseBuilder {
      * @return A ResponseBuilder to add additional information.
      */
     public ResponseBuilder type(String type) {
-        response.getHeader().addParameter("Accept", type);
         response.getContent().setMimetype(type);
         return this;
     }

--- a/src/test/java/de/hanbei/httpserver/MockHttpServerTest.java
+++ b/src/test/java/de/hanbei/httpserver/MockHttpServerTest.java
@@ -119,6 +119,7 @@ public class MockHttpServerTest {
         httpget.setHeader("Accept-Charset", Charsets.ISO_8859_1.name());
         HttpResponse response = httpclient.execute(httpget);
         assertEquals(200, response.getStatusLine().getStatusCode());
+        assertEquals("text/plain; charset=iso-8859-1", response.getFirstHeader("Content-Type").getValue());
         HttpEntity entity = response.getEntity();
         String content = IOUtils.toString(entity.getContent(), Charsets.ISO_8859_1);
         assertEquals("Cæelo", content.trim());


### PR DESCRIPTION
Headers are not sent for prepared Responses, i.e. also "Content-Type" is never sent. The reason is, that additional headers are ignored after `httpExchange.sendResponseHeaders(statusCode, max(0, length));` is called. I modified a few lines to solve this problem.
